### PR TITLE
docs: correct Damavand Power Plant spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## 🔍 About Me
 - **📚** PhD student in Electrical Engineering at **York University**.
 - **🎓** Master's graduate from **Sharif University of Technology**, with innovative contributions in **dynamic state estimation** and **smart grids**.
-- **🏭** Hands-on experience at **Damvand Power Plant**, the largest in the Middle East.
+- **🏭** Hands-on experience at **Damavand Power Plant**, the largest in the Middle East.
 - **🏆** Recognized for ranking **26th** nationwide in Power Systems and Power Electronics for the MSc entrance exam.
 
 <hr>


### PR DESCRIPTION
## Summary
- fix typo: Damvand -> Damavand in README experience section

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689161a6947c832092ddcfe3f9d627e1